### PR TITLE
Replace the typo of 'refered' with 'referred'

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ which should be validated. Using `be_valid` does not guarantee that the problem
       end
     end
 
-    # prefered
+    # preferred
     describe '#title'
       it 'is required' do
         article.title = nil


### PR DESCRIPTION
A very small typo, just happen to notice while reading.
