### PR TITLE
Fix code area overflow of the RSpec chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ You can generate a PDF or an HTML copy of this guide using
 
   # bad
   it "should return true"
+  ```
 
 * Write expectations at a high level, removed from logic and implementation details.
 


### PR DESCRIPTION
- insert ``` to expected place
